### PR TITLE
Blog posts meta content

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -30,7 +30,7 @@ if ( ! function_exists( 'nightingale_2_0_posted_on' ) ) :
 			'<a href="' . esc_url( get_permalink() ) . '" rel="bookmark">' . $time_string . '</a>'
 		);
 
-		echo '<span class="posted-on">' . $posted_on . '</span>'; // WPCS: XSS OK.
+		echo '<p><span class="nhsuk-u-visually-hidden">Posted on: </span>' . $time_string . '</p>'; // WPCS: XSS OK.
 
 	}
 endif;
@@ -40,13 +40,9 @@ if ( ! function_exists( 'nightingale_2_0_posted_by' ) ) :
 	 * Prints HTML with meta information for the current author.
 	 */
 	function nightingale_2_0_posted_by() {
-		$byline = sprintf(
-			/* translators: %s: post author. */
-			esc_html_x( 'by %s', 'post author', 'nightingale-2-0' ),
-			'<span class="author vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author() ) . '</a></span>'
-		);
 
-		echo '<span class="byline"> ' . $byline . '</span>'; // WPCS: XSS OK.
+		echo '<p><span class="nhsuk-u-visually-hidden">Posted by: </span><a class="url fn n" 
+ href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author() ) . '</a></p>'; // WPCS: XSS OK.
 
 	}
 endif;
@@ -62,19 +58,21 @@ if ( ! function_exists( 'nightingale_2_0_entry_footer' ) ) :
 			$categories_list = get_the_category_list( esc_html__( ', ', 'nightingale-2-0' ) );
 			if ( $categories_list ) {
 				/* translators: 1: list of categories. */
-				printf( '<span class="cat-links">' . esc_html__( 'Posted in %1$s', 'nightingale-2-0' ) . '</span>', $categories_list ); // WPCS: XSS OK.
+				printf( '<p class="cat-links">' . esc_html__( 'Posted in %1$s', 'nightingale-2-0' ) . '</p>',
+                    $categories_list ); // WPCS: XSS OK.
 			}
 
 			/* translators: used between list items, there is a space after the comma */
 			$tags_list = get_the_tag_list( '', esc_html_x( ', ', 'list item separator', 'nightingale-2-0' ) );
 			if ( $tags_list ) {
 				/* translators: 1: list of tags. */
-				printf( '<span class="tags-links">' . esc_html__( 'Tagged %1$s', 'nightingale-2-0' ) . '</span>', $tags_list ); // WPCS: XSS OK.
+				printf( '<p class="tags-links">' . esc_html__( 'Tagged %1$s', 'nightingale-2-0' ) . '</p>',
+                    $tags_list ); // WPCS: XSS OK.
 			}
 		}
 
 		if ( ! is_single() && ! post_password_required() && ( comments_open() || get_comments_number() ) ) {
-			echo '<span class="comments-link">';
+			echo '<p class="comments-link">';
 			comments_popup_link(
 				sprintf(
 					wp_kses(
@@ -89,14 +87,14 @@ if ( ! function_exists( 'nightingale_2_0_entry_footer' ) ) :
 					get_the_title()
 				)
 			);
-			echo '</span>';
+			echo '</p>';
 		}
 
 		edit_post_link(
 			sprintf(
 				wp_kses(
 					/* translators: %s: Name of current post. Only visible to screen readers */
-					__( 'Edit <span class="screen-reader-text">%s</span>', 'nightingale-2-0' ),
+					__( 'Edit <p class="screen-reader-text">%s</p>', 'nightingale-2-0' ),
 					array(
 						'span' => array(
 							'class' => array(),
@@ -105,8 +103,8 @@ if ( ! function_exists( 'nightingale_2_0_entry_footer' ) ) :
 				),
 				get_the_title()
 			),
-			'<span class="edit-link">',
-			'</span>'
+			'<p class="edit-link">',
+			'</p>'
 		);
 	}
 endif;

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -10,28 +10,30 @@
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
-	<header class="entry-header">
+	<header class="article-header">
 		<?php
 		if ( is_singular() ) :
-			the_title( '<h1 class="entry-title">', '</h1>' );
+			the_title( '<h1 class="nhsuk-heading-xl">', '</h1>' );
 		else :
-			the_title( '<h2 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h2>' );
+			the_title( '<h2 class="nhsuk-heading-l"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h2>' );
 		endif;
 
 		if ( 'post' === get_post_type() ) :
 			?>
-			<div class="entry-meta">
+            <div class="nhsuk-review-date">
+                <p class="nhsuk-body-s">
 				<?php
+                nightingale_2_0_posted_by();
 				nightingale_2_0_posted_on();
-				nightingale_2_0_posted_by();
 				?>
-			</div><!-- .entry-meta -->
+                </p>
+			</div><!-- .article-meta -->
 		<?php endif; ?>
-	</header><!-- .entry-header -->
+	</header><!-- .article-header -->
 
 	<?php nightingale_2_0_post_thumbnail(); ?>
 
-	<div class="entry-content">
+	<article>
 		<?php
 		the_content( sprintf(
 			wp_kses(
@@ -51,9 +53,17 @@
 			'after'  => '</div>',
 		) );
 		?>
-	</div><!-- .entry-content -->
+    </article><!-- .article-content -->
 
-	<footer class="entry-footer">
+	<footer class="article-footer"><details class="nhsuk-details nhsuk-expander">
+            <summary class="nhsuk-details__summary">
+    <span class="nhsuk-details__summary-text">
+      Meta information
+    </span>
+            </summary>
+            <div class="nhsuk-details__text">
 		<?php nightingale_2_0_entry_footer(); ?>
+            </div>
+        </details>
 	</footer><!-- .entry-footer -->
 </article><!-- #post-<?php the_ID(); ?> -->


### PR DESCRIPTION
 - Author and date moved to <p> elements with visually hidden screen-reader components to make them logical components
 - category, tags and edit links moved into expander titled "meta information" to take outside of the view logic.