### PR TITLE
added flag in functions.php to disable xml / rpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@
  - email tony.blacker@leadershipacademy.nhs.uk for the ACF Pro license key, and you will need to install this manually
  - Activate the `ACF Pro` and `NHS Leadership Academy Blocks for Gutenburg` plugins - either from the themes page or in plugins. *Install and enable ACF Pro before the blocks plugin to ensure full functionality*
  
+## To be aware of
+ - XML/RPC will be disabled on activation of the theme. This is a sensible security setting, and if you currently use
+  XML RPC I suggest you have a Google to see exactly why its a bad idea to leave it turned on.
+  
 ## Progress
  - [x] Load in the NHS Frontend library
  - [x] Style header, amend markup to match expected output

--- a/functions.php
+++ b/functions.php
@@ -400,4 +400,7 @@ if ( defined( 'JETPACK__VERSION' ) ) {
     require get_template_directory() . '/inc/jetpack.php';
 
 }
-
+/**
+ * Disable XML RPC by default
+ */
+add_filter( 'xmlrpc_enabled', '__return_false' );


### PR DESCRIPTION
There are better ways of doing this, but by adding it to themes functions.php file it is automatically disabled on theme activation.

So even if we disable the function at server level, this code adds no overhead but does add in a sense check safety net.