### PR TITLE
added sense check query inside nightingale_loadcss_files-function

### DIFF
--- a/inc/performance-optimisations.php
+++ b/inc/performance-optimisations.php
@@ -46,8 +46,9 @@ function nightingale_loadcss_files( $html, $handle, $href ) {
 	$dom = new DOMDocument();
 	$dom->loadHTML( $html );
 	$a = $dom->getElementById( $handle . '-css' );
-
-	return "<script>loadCSS('" . $a->getAttribute( 'href' ) . "',0,'" . $a->getAttribute( 'media' ) . "');</script>\n";
+	if ( !empty( $a ) ) {
+		return "<script>loadCSS('" . $a->getAttribute( 'href' ) . "',0,'" . $a->getAttribute( 'media' ) . "');</script>\n";
+	}
 }
 
 add_filter( 'style_loader_tag', 'nightingale_loadcss_files', 9999, 3 );


### PR DESCRIPTION
closes #66 

Some plugins send empty attributes when using DOMDocument to identify stylesheets. This appears to be present on JetPack, but is also an issue with some less used plugins. I have added in a query to ensure the domElement is populated before attempting to generate the loadCSS script wrapper. This effectively excludes these plugin file's stylesheets from the loadCSS routine.