### PR TITLE
Logo re-worked entirely

### DIFF
--- a/assets/scss/header.scss
+++ b/assets/scss/header.scss
@@ -1,5 +1,48 @@
 .nhsuk-header--transactional {
+  .nhsuk-header__logo {
+    height: auto;
+    a.nhsuk-header__link {
+      height: auto;
+      width: auto;
+      text-decoration: none;
+
+      .nhsuk-header__transactional-service-name {
+        width: max-content;
+        color: $color_nhsuk-white;
+        font-size: 1.25rem;
+        font-weight: 700;
+        padding: 20px 10px 20px 100px;
+        position: absolute;
+        top: 30px;
+      }
+
+      .nhsuk-header__organisational-service-name {
+        width: max-content;
+        color: $color_nhsuk-white;
+        font-size: 1.25rem;
+        font-weight: 700;
+        padding: 0 10px 0 0;
+      }
+
+      .nhsuk-header__organisational-qualifier {
+        color: $color_nhsuk-white;
+        width: max-content;
+        padding: 0;
+      }
+    }
+  }
   .nhsuk-header__inverted {
+    .nhsuk-header__logo {
+      a.nhsuk-header__link {
+        .nhsuk-header__transactional-service-name, .nhsuk-header__organisational-service-name {
+          color: $color-nhsuk-black;
+        }
+
+        .nhsuk-header__organisational-qualifier {
+          color: $color-nhsuk-bright-blue;
+        }
+      }
+    }
     background: $color_nhsuk-white;
     color: $color_nhsuk-black;
 

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -122,6 +122,65 @@ function nightingale_customize_register( $wp_customize ) {
 	);
 
 	/*
+ * -----------------------------------------------------------
+ * LOGO Generation
+ * -----------------------------------------------------------
+ */
+	$wp_customize->add_setting(
+		'logo_type',
+		array(
+			'default'           => 'transaction',
+			'sanitize_callback' => 'esc_attr',
+		)
+	);
+	$wp_customize->add_control(
+		'logo_type',
+		array(
+			'label'   => esc_html__( 'Site identifier', 'nightingale' ),
+			'description' => esc_html__( 'You can create your own site identity. This only takes effect if you have not uploaded a site logo. The options are transactional (NHS logo, your org name to the right) or organisational (NHS logo, your org name underneath and a department or qualifier under that). Both are accepted NHS design patterns.', 'nightingale' ),
+			'section' => 'section_header',
+			'type'    => 'radio',
+			'choices' => array(
+				'transaction'   => esc_html__( 'Transactional', 'nightingale' ),
+				'organisation' => esc_html__( 'Organisational', 'nightingale' ),
+			),
+		)
+	);
+
+	$wp_customize->add_setting(
+		'logo_title',
+		array(
+			'default'           => bloginfo( 'name' ),
+			'sanitize_callback' => 'esc_attr',
+		)
+	);
+	$wp_customize->add_control(
+		'logo_title',
+		array(
+			'label'   => esc_html__( 'Title to show in generated logo', 'nightingale' ),
+			'section' => 'section_header',
+			'type'    => 'text',
+		)
+	);
+
+	$wp_customize->add_setting(
+		'logo_qualifier',
+		array(
+			'default'           => '',
+			'sanitize_callback' => 'esc_attr',
+		)
+	);
+	$wp_customize->add_control(
+		'logo_qualifier',
+		array(
+			'label'         => esc_html__( 'Qualifier to show in generated logo', 'nightingale' ),
+			'description'   => esc_html__('this will only show in transactional logos and is either your department or local qualifier', 'nightingale'),
+			'section'       => 'section_header',
+			'type'          => 'text',
+		)
+	);
+
+	/*
 	 * ------------------------------------------------------------
 	 * SECTION: Emergency Alert Field
 	 * ------------------------------------------------------------

--- a/partials/header-inverted.php
+++ b/partials/header-inverted.php
@@ -10,42 +10,11 @@
  * @copyright NHS Leadership Academy, Tony Blacker
  * @version 1.1 21st August 2019
  */
-
 ?>
 <div class="nhsuk-header nhsuk-header__inverted">
 	<div class="nhsuk-width-container nhsuk-header__container">
-		<?php
-		if ( has_custom_logo() ) {
-			?>
-			<div class="nhsuk-header__logo">
-				<?php the_custom_logo(); ?>
-			</div>
-			<?php if ( get_theme_mod( 'show_sitename' ) === 'yes' ) { ?>
-				<div class="nhsuk-header__transactional-service-name">
-					<a class="nhsuk-header__transactional-service-name--link" href="/"><?php bloginfo( 'name' ); ?></a>
-				</div>
-				<?php
-			}
-		} else {
-			?>
-			<div class="nhsuk-header__logo">
-				<a class="nhsuk-header__link" href="/" aria-label="NHS homepage">
-					<svg class="nhsuk-logo nhsuk-logo--white" xmlns="http://www.w3.org/2000/svg" role="presentation" focusable="false" viewBox="0 0 40 16">
-						<path fill="#fff" d="M0 0h40v16H0z"></path>
-						<path fill="#005eb8" d="M3.9 1.5h4.4l2.6 9h.1l1.8-9h3.3l-2.8 13H9l-2.7-9h-.1l-1.8 9H1.1M17.3 1.5h3.6l-1 4.9h4L25 1.5h3.5l-2.7 13h-3.5l1.1-5.6h-4.1l-1.2 5.6h-3.4M37.7 4.4c-.7-.3-1.6-.6-2.9-.6-1.4 0-2.5.2-2.5 1.3 0 1.8 5.1 1.2 5.1 5.1 0 3.6-3.3 4.5-6.4 4.5-1.3 0-2.9-.3-4-.7l.8-2.7c.7.4 2.1.7 3.2.7s2.8-.2 2.8-1.5c0-2.1-5.1-1.3-5.1-5 0-3.4 2.9-4.4 5.8-4.4 1.6 0 3.1.2 4 .6"></path>
-						<image src="https://assets.nhs.uk/images/nhs-logo.png" xlink:href=""></image>
-					</svg>
-				</a>
-			</div>
-		<?php if ( get_theme_mod( 'show_sitename' ) === 'yes' ) { ?>
-				<div class="nhsuk-header__transactional-service-name">
-					<a class="nhsuk-header__transactional-service-name--link" href="/"><?php bloginfo( 'name' ); ?></a>
-				</div>
-				<?php
-			}
-		}
-		?>
 
+		<?php get_template_part( 'partials/logo' ); ?>
 		<div class="nhsuk-header__content" id="content-header">
 
 			<div class="nhsuk-header__menu">

--- a/partials/header-normal.php
+++ b/partials/header-normal.php
@@ -14,37 +14,7 @@
 ?>
 <div class="nhsuk-width-container nhsuk-header__container">
 
-	<?php
-	if ( has_custom_logo() ) {
-		?>
-		<div class="nhsuk-header__logo">
-			<?php the_custom_logo(); ?>
-		</div>
-	<?php if ( get_theme_mod( 'show_sitename' ) === 'yes' ) { ?>
-			<div class="nhsuk-header__transactional-service-name">
-				<a class="nhsuk-header__transactional-service-name--link" href="/"><?php bloginfo( 'name' ); ?></a>
-			</div>
-			<?php
-		}
-	} else {
-		?>
-		<div class="nhsuk-header__logo">
-			<a class="nhsuk-header__link" href="/" aria-label="NHS homepage">
-				<svg class="nhsuk-logo nhsuk-logo--white" xmlns="http://www.w3.org/2000/svg" role="presentation" focusable="false" viewBox="0 0 40 16">
-					<path fill="#fff" d="M0 0h40v16H0z"></path>
-					<path fill="#005eb8" d="M3.9 1.5h4.4l2.6 9h.1l1.8-9h3.3l-2.8 13H9l-2.7-9h-.1l-1.8 9H1.1M17.3 1.5h3.6l-1 4.9h4L25 1.5h3.5l-2.7 13h-3.5l1.1-5.6h-4.1l-1.2 5.6h-3.4M37.7 4.4c-.7-.3-1.6-.6-2.9-.6-1.4 0-2.5.2-2.5 1.3 0 1.8 5.1 1.2 5.1 5.1 0 3.6-3.3 4.5-6.4 4.5-1.3 0-2.9-.3-4-.7l.8-2.7c.7.4 2.1.7 3.2.7s2.8-.2 2.8-1.5c0-2.1-5.1-1.3-5.1-5 0-3.4 2.9-4.4 5.8-4.4 1.6 0 3.1.2 4 .6"></path>
-					<image src="https://assets.nhs.uk/images/nhs-logo.png" xlink:href=""></image>
-				</svg>
-			</a>
-		</div>
-	<?php if ( get_theme_mod( 'show_sitename' ) === 'yes' ) { ?>
-			<div class="nhsuk-header__transactional-service-name">
-				<a class="nhsuk-header__transactional-service-name--link" href="/"><?php bloginfo( 'name' ); ?></a>
-			</div>
-			<?php
-		}
-	}
-	?>
+    <?php get_template_part( 'partials/logo' ); ?>
 	<div class="nhsuk-header__content" id="content-header">
 
 		<div class="nhsuk-header__menu">

--- a/partials/logo.php
+++ b/partials/logo.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * The logo generator
+ *
+ * This is the area to customise the NHS logo if a full graphic is not uploaded
+ *
+ * @link https://www.england.nhs.uk/nhsidentity/identity-guidelines/organisational-logos/
+ *
+ * @package Nightingale
+ * @copyright NHS Leadership Academy, Tony Blacker
+ * @version 1.0 1st October 2019
+ */
+?>
+<div class="nhsuk-header__logo">
+        <a class="nhsuk-header__link" href="/" aria-label="<?php bloginfo( 'name' ); ?> homepage">
+            <?php
+            if ( has_custom_logo() ) {
+                ?>
+                    <?php the_custom_logo(); ?>
+            <?php if ( get_theme_mod( 'show_sitename' ) === 'yes' ) { ?>
+                    <div class="nhsuk-header__transactional-service-name">
+                        <a class="nhsuk-header__transactional-service-name--link" href="/"><?php bloginfo( 'name' ); ?></a>
+                    </div>
+                    <?php
+                }
+            } else {
+                ?>
+                        <svg class="nhsuk-logo nhsuk-logo--white" xmlns="http://www.w3.org/2000/svg" role="presentation" focusable="false" viewBox="0 0 40 16">
+                            <path fill="#fff" d="M0 0h40v16H0z"></path>
+                            <path fill="#005eb8" d="M3.9 1.5h4.4l2.6 9h.1l1.8-9h3.3l-2.8 13H9l-2.7-9h-.1l-1.8 9H1.1M17.3 1.5h3.6l-1 4.9h4L25 1.5h3.5l-2.7 13h-3.5l1.1-5.6h-4.1l-1.2 5.6h-3.4M37.7 4.4c-.7-.3-1.6-.6-2.9-.6-1.4 0-2.5.2-2.5 1.3 0 1.8 5.1 1.2 5.1 5.1 0 3.6-3.3 4.5-6.4 4.5-1.3 0-2.9-.3-4-.7l.8-2.7c.7.4 2.1.7 3.2.7s2.8-.2 2.8-1.5c0-2.1-5.1-1.3-5.1-5 0-3.4 2.9-4.4 5.8-4.4 1.6 0 3.1.2 4 .6"></path>
+                            <image src="https://assets.nhs.uk/images/nhs-logo.png" xlink:href=""></image>
+                        </svg>
+            <?php if ( get_theme_mod( 'show_sitename' ) === 'yes' ) { ?>
+                    <div class="nhsuk-header__<? echo get_theme_mod( 'logo_type' ); ?>al-service-name">
+                        <?php echo get_theme_mod( 'logo_title' ); ?>
+                    </div>
+                    <?php
+                    if ( 'organisation' === get_theme_mod( 'logo_type' ) ) { ?>
+                        <div class="nhsuk-header__organisational-qualifier"><?php echo get_theme_mod( 'logo_qualifier' ); ?></div>
+                    <?php
+                    }
+                }
+            }
+            ?>
+        </a>
+    </div>

--- a/style-gutenburg.css
+++ b/style-gutenburg.css
@@ -10133,6 +10133,10 @@ section {
   display: -ms-flex;
 }
 
+.edit-post-visual-editor .nhsuk-header__search-form {
+  height: 0;
+}
+
 .wp-block {
   max-width: 800px;
 }

--- a/style-gutenburg.scss
+++ b/style-gutenburg.scss
@@ -53,6 +53,9 @@ ul {
   div.components-toolbar>div {
     display: -ms-flex;
   }
+  .nhsuk-header__search-form {
+    height: 0;
+  }
 }
 
 .wp-block{

--- a/style.css
+++ b/style.css
@@ -11079,9 +11079,51 @@ b {
   color: #ffffff;
 }
 
+.nhsuk-header--transactional .nhsuk-header__logo {
+  height: auto;
+}
+
+.nhsuk-header--transactional .nhsuk-header__logo a.nhsuk-header__link {
+  height: auto;
+  width: auto;
+  text-decoration: none;
+}
+
+.nhsuk-header--transactional .nhsuk-header__logo a.nhsuk-header__link .nhsuk-header__transactional-service-name {
+  width: max-content;
+  color: #ffffff;
+  font-size: 1.25rem;
+  font-weight: 700;
+  padding: 20px 10px 20px 100px;
+  position: absolute;
+  top: 30px;
+}
+
+.nhsuk-header--transactional .nhsuk-header__logo a.nhsuk-header__link .nhsuk-header__organisational-service-name {
+  width: max-content;
+  color: #ffffff;
+  font-size: 1.25rem;
+  font-weight: 700;
+  padding: 0 10px 0 0;
+}
+
+.nhsuk-header--transactional .nhsuk-header__logo a.nhsuk-header__link .nhsuk-header__organisational-qualifier {
+  color: #ffffff;
+  width: max-content;
+  padding: 0;
+}
+
 .nhsuk-header--transactional .nhsuk-header__inverted {
   background: #ffffff;
   color: #212b32;
+}
+
+.nhsuk-header--transactional .nhsuk-header__inverted .nhsuk-header__logo a.nhsuk-header__link .nhsuk-header__transactional-service-name, .nhsuk-header--transactional .nhsuk-header__inverted .nhsuk-header__logo a.nhsuk-header__link .nhsuk-header__organisational-service-name {
+  color: #212b32;
+}
+
+.nhsuk-header--transactional .nhsuk-header__inverted .nhsuk-header__logo a.nhsuk-header__link .nhsuk-header__organisational-qualifier {
+  color: #0072ce;
 }
 
 .nhsuk-header--transactional .nhsuk-header__inverted a.nhsuk-header__transactional-service-name--link {


### PR DESCRIPTION
Options are now:
 - upload image as a logo (in which case you can choose to show or hide the site name)
 - Have a transactional logo - this is the NHS logo with a title next to it in NHSUK styling
 - Have an organisational logo - NHS logo, with title underneath and a qualifier below that.

All three work on either standard (blue) header or inverted (white) header, and are fully customisable via the admin customiser.