### PR TITLE
Reworked header css:

### DIFF
--- a/assets/scss/generic-overrides.scss
+++ b/assets/scss/generic-overrides.scss
@@ -66,3 +66,18 @@
 .is-style-outline .wp-block-button__link {
   color: $color_nhsuk-blue;
 }
+.error-404 {
+  .nhsuk-header__search-toggle, .nhsuk-search__close {
+    display: none;
+  }
+  .nhsuk-header__search-wrap {
+    display: inline-block;
+    width: 267px;
+    border: 2px solid $color_nhsuk-blue;
+    border-radius: 4px;
+    input[type="text"] {
+      border-radius: 2px 0 0 2px;
+      border-right: 2px solid #005eb8;
+    }
+  }
+}

--- a/assets/scss/header.scss
+++ b/assets/scss/header.scss
@@ -1,6 +1,13 @@
 .nhsuk-header--transactional {
   .nhsuk-header__logo {
+    position: relative;
+    top: -8px;
     height: auto;
+    padding: 20px 0 10px;
+    .nhsuk-logo {
+      position: relative;
+      top: 8px;
+    }
     a.nhsuk-header__link {
       height: auto;
       width: auto;
@@ -11,13 +18,11 @@
         color: $color_nhsuk-white;
         font-size: 1.25rem;
         font-weight: 700;
-        padding: 20px 10px 20px 100px;
-        position: absolute;
-        top: 30px;
+        display: contents;
       }
 
       .nhsuk-header__organisational-service-name {
-        width: max-content;
+        width: auto;
         color: $color_nhsuk-white;
         font-size: 1.25rem;
         font-weight: 700;
@@ -26,7 +31,7 @@
 
       .nhsuk-header__organisational-qualifier {
         color: $color_nhsuk-white;
-        width: max-content;
+        width: auto;
         padding: 0;
       }
     }
@@ -89,7 +94,6 @@
       border-color: $color_nhsuk-blue;
       box-shadow: none;
       color: $color_nhsuk-blue;
-      right: 20px;
 
       .nhsuk-icon__search {
         fill: $color_nhsuk-blue;
@@ -107,7 +111,6 @@
   }
   .nhsuk-header__menu-toggle {
     margin-right: -4px;
-    margin-top: 50px;
   }
   @media (min-width: 40.0625em) {
     margin-top: 0;
@@ -116,5 +119,23 @@
     .autocomplete__input {
       height: 52px;
     }
+    .nhsuk-header__content {
+      float: right ;
+    }
+    .nhsuk-header__menu {
+      float: right;
+      margin-left: 0;
+    }
+    .nhsuk-header__search {
+      margin-right: 16px;
+      float: right;
+    }
+    .nhsuk-header__logo {
+      padding: 20px 16px 0;
+    }
+    .nhsuk-header__search-toggle {
+      position: relative;
+    }
+
   }
 }

--- a/style-gutenburg.css
+++ b/style-gutenburg.css
@@ -10180,6 +10180,22 @@ section {
   color: #005eb8;
 }
 
+.error-404 .nhsuk-header__search-toggle, .error-404 .nhsuk-search__close {
+  display: none;
+}
+
+.error-404 .nhsuk-header__search-wrap {
+  display: inline-block;
+  width: 267px;
+  border: 2px solid #005eb8;
+  border-radius: 4px;
+}
+
+.error-404 .nhsuk-header__search-wrap input[type="text"] {
+  border-radius: 2px 0 0 2px;
+  border-right: 2px solid #005eb8;
+}
+
 .has-white-color {
   color: #ffffff;
 }

--- a/style.css
+++ b/style.css
@@ -11167,6 +11167,22 @@ b {
   color: #005eb8;
 }
 
+.error-404 .nhsuk-header__search-toggle, .error-404 .nhsuk-search__close {
+  display: none;
+}
+
+.error-404 .nhsuk-header__search-wrap {
+  display: inline-block;
+  width: 267px;
+  border: 2px solid #005eb8;
+  border-radius: 4px;
+}
+
+.error-404 .nhsuk-header__search-wrap input[type="text"] {
+  border-radius: 2px 0 0 2px;
+  border-right: 2px solid #005eb8;
+}
+
 .has-white-color {
   color: #ffffff;
 }
@@ -11350,7 +11366,15 @@ b {
 }
 
 .nhsuk-header--transactional .nhsuk-header__logo {
+  position: relative;
+  top: -8px;
   height: auto;
+  padding: 20px 0 10px;
+}
+
+.nhsuk-header--transactional .nhsuk-header__logo .nhsuk-logo {
+  position: relative;
+  top: 8px;
 }
 
 .nhsuk-header--transactional .nhsuk-header__logo a.nhsuk-header__link {
@@ -11364,13 +11388,11 @@ b {
   color: #ffffff;
   font-size: 1.25rem;
   font-weight: 700;
-  padding: 20px 10px 20px 100px;
-  position: absolute;
-  top: 30px;
+  display: contents;
 }
 
 .nhsuk-header--transactional .nhsuk-header__logo a.nhsuk-header__link .nhsuk-header__organisational-service-name {
-  width: max-content;
+  width: auto;
   color: #ffffff;
   font-size: 1.25rem;
   font-weight: 700;
@@ -11379,7 +11401,7 @@ b {
 
 .nhsuk-header--transactional .nhsuk-header__logo a.nhsuk-header__link .nhsuk-header__organisational-qualifier {
   color: #ffffff;
-  width: max-content;
+  width: auto;
   padding: 0;
 }
 
@@ -11438,7 +11460,6 @@ b {
   border-color: #005eb8;
   box-shadow: none;
   color: #005eb8;
-  right: 20px;
 }
 
 .nhsuk-header--transactional .nhsuk-header__inverted .nhsuk-header__search-toggle .nhsuk-icon__search {
@@ -11456,7 +11477,6 @@ b {
 
 .nhsuk-header--transactional .nhsuk-header__menu-toggle {
   margin-right: -4px;
-  margin-top: 50px;
 }
 
 @media (min-width: 40.0625em) {
@@ -11468,6 +11488,23 @@ b {
 @media (max-width: 40.0525em) {
   .nhsuk-header--transactional .autocomplete__input {
     height: 52px;
+  }
+  .nhsuk-header--transactional .nhsuk-header__content {
+    float: right;
+  }
+  .nhsuk-header--transactional .nhsuk-header__menu {
+    float: right;
+    margin-left: 0;
+  }
+  .nhsuk-header--transactional .nhsuk-header__search {
+    margin-right: 16px;
+    float: right;
+  }
+  .nhsuk-header--transactional .nhsuk-header__logo {
+    padding: 20px 16px 0;
+  }
+  .nhsuk-header--transactional .nhsuk-header__search-toggle {
+    position: relative;
   }
 }
 


### PR DESCRIPTION
 - Moved menu and search to float: right rather than absolute position
 - Changed transactional title type to display: contents to allow wrapping on long titles
 - Changed NHS logo to have 8px drop to display transactional title as correct logo style
 - Modified organisational logo / text accordingly
 - changed margins on search and menu to move according to device width AND text length