### PR TITLE
[refs #DI-2784] Hide author usernames in rss feeds

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -478,11 +478,11 @@ if ( ! is_admin() ) {
 /**
  * For security prevent RSS feed disclosing author usernames
  */
-function nhsla_check_author( $display_name ) {
+function nightingale_check_author( $display_name ) {
     if ( is_feed() ) {
 		// display user id instead of name
         return get_the_author_meta( 'ID' );
     }
     return $display_name;
 }
-add_filter( 'the_author', 'nhsla_check_author', PHP_INT_MAX, 1 );
+add_filter( 'the_author', 'nightingale_check_author', PHP_INT_MAX, 1 );

--- a/functions.php
+++ b/functions.php
@@ -474,3 +474,15 @@ require get_template_directory() . '/inc/class-comment-author-role-label.php';
 if ( ! is_admin() ) {
 	require get_template_directory() . '/inc/dynamic-blocks.php';
 }
+
+/**
+ * For security prevent RSS feed disclosing author usernames
+ */
+function nhsla_check_author( $display_name ) {
+    if ( is_feed() ) {
+		// display user id instead of name
+        return get_the_author_meta( 'ID' );
+    }
+    return $display_name;
+}
+add_filter( 'the_author', 'nhsla_check_author', PHP_INT_MAX, 1 );


### PR DESCRIPTION
Security fix to prevent possible admin usernames being exposed in RSS.

Before (revealing username):
![Screenshot 2021-01-18 at 13 56 17](https://user-images.githubusercontent.com/1991226/105055223-c13d8600-5a6a-11eb-9dc8-e256bba1954a.png)

After (only reveals user id):
![Screenshot 2021-01-19 at 15 18 58](https://user-images.githubusercontent.com/1991226/105055218-c00c5900-5a6a-11eb-8159-ce54cc383032.png)