### PR TITLE
[refs #DI-2783] Hide login hints

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -486,3 +486,11 @@ function nightingale_check_author( $display_name ) {
     return $display_name;
 }
 add_filter( 'the_author', 'nightingale_check_author', PHP_INT_MAX, 1 );
+
+/**
+ * For security prevent password reset error message providing info on user emails
+ */
+function nightingale_no_login_hints ( $error ) {
+	return 'If your email has been found in our database you will receive a reset link';
+}
+add_filter ( 'login_errors', 'nightingale_no_login_hints' );

--- a/functions.php
+++ b/functions.php
@@ -491,6 +491,6 @@ add_filter( 'the_author', 'nightingale_check_author', 9999, 1 );
  * For security prevent password reset error message providing info on user emails
  */
 function nightingale_no_login_hints ( $error ) {
-	return __('If your email has been found in our database you will receive a reset link');
+	return __('If your email has been found in our database you will receive a reset link' , 'nightingale');
 }
 add_filter ( 'login_errors', 'nightingale_no_login_hints' );

--- a/functions.php
+++ b/functions.php
@@ -485,12 +485,12 @@ function nightingale_check_author( $display_name ) {
     }
     return $display_name;
 }
-add_filter( 'the_author', 'nightingale_check_author', PHP_INT_MAX, 1 );
+add_filter( 'the_author', 'nightingale_check_author', 9999, 1 );
 
 /**
  * For security prevent password reset error message providing info on user emails
  */
 function nightingale_no_login_hints ( $error ) {
-	return 'If your email has been found in our database you will receive a reset link';
+	return _('If your email has been found in our database you will receive a reset link');
 }
 add_filter ( 'login_errors', 'nightingale_no_login_hints' );

--- a/functions.php
+++ b/functions.php
@@ -491,6 +491,6 @@ add_filter( 'the_author', 'nightingale_check_author', 9999, 1 );
  * For security prevent password reset error message providing info on user emails
  */
 function nightingale_no_login_hints ( $error ) {
-	return _('If your email has been found in our database you will receive a reset link');
+	return __('If your email has been found in our database you will receive a reset link');
 }
 add_filter ( 'login_errors', 'nightingale_no_login_hints' );


### PR DESCRIPTION
Prevent email enumeration attacks by not giving useful information about
email addresses used in login attempts.

Before:
![Screenshot 2021-01-19 at 16 28 22](https://user-images.githubusercontent.com/1991226/105158653-209ca400-5b06-11eb-872f-4849c4e3abde.png)

After:
![Screenshot 2021-01-20 at 09 52 54](https://user-images.githubusercontent.com/1991226/105158590-09f64d00-5b06-11eb-9b89-5fc8ac534d4e.png)
