### PR TITLE
Post Listings thumbnail tweak:

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -162,6 +162,12 @@ function nightingale_setup() {
 
 	remove_theme_support( 'custom-header' );
 	remove_theme_support( 'custom-background' );
+	/*
+	 * Add new suare image thumbnails to give nicer blog posts grid layout
+	 */
+	add_image_size( 'nightingale-square-sm', 200, 200, array( 'centre', 'center' ) ); // Small square with hard crop from middle.
+	add_image_size( 'nightingale-square-md', 500, 500, array( 'centre', 'center' ) ); // Medium square with hard crop from middle.
+	add_image_size( 'nightingale-square-lg', 1000, 1000, array( 'centre', 'center' ) ); // Large square with hard crop from middle.
 
 }
 

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -441,7 +441,7 @@ function nightingale_add_blog_settings( $wp_customize ) {
 			'settings'    => 'blog_image_display',
 			'section'     => 'blog_panel',
 			'type'        => 'radio',
-			'label'       => esc_html__( 'Image on Blog Listing ', 'nightingale' ),
+			'label'       => esc_html__( 'Images on Blog Listing ', 'nightingale' ),
 			'description' => esc_html__( 'Choose whether to display image on blog listing page as square or default (square will ensure all blocks are consistently laid out)', 'nightingale' ),
 			'choices'     => array(
 				'default'  => esc_html__( 'Leave as default proportions', 'nightingale' ),

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -442,7 +442,7 @@ function nightingale_add_blog_settings( $wp_customize ) {
 			'section'     => 'blog_panel',
 			'type'        => 'radio',
 			'label'       => esc_html__( 'Images on Blog Listing ', 'nightingale' ),
-			'description' => esc_html__( 'Choose whether to display image on blog listing page as square or default (square will ensure all blocks are consistently laid out)', 'nightingale' ),
+			'description' => esc_html__( 'Choose whether to display images on blog listing page as square or default (square will ensure all blocks are consistently laid out)', 'nightingale' ),
 			'choices'     => array(
 				'default'  => esc_html__( 'Leave as default proportions', 'nightingale' ),
 				'nightingale-square-md' => esc_html__( 'Show as square (images may be cropped)', 'nightingale' ),

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -422,6 +422,35 @@ function nightingale_add_blog_settings( $wp_customize ) {
 	);
 
 	$wp_customize->add_setting(
+	// $id
+		'blog_image_display',
+		// $args
+		array(
+			'default'           => 'default',
+			'type'              => 'theme_mod',
+			'capability'        => 'edit_theme_options',
+			'sanitize_callback' => 'nightingale_sanitize_select',
+		)
+	);
+
+	$wp_customize->add_control(
+	// $id
+		'blog_image_display',
+		// $args
+		array(
+			'settings'    => 'blog_image_display',
+			'section'     => 'blog_panel',
+			'type'        => 'radio',
+			'label'       => esc_html__( 'Image on Blog Listing ', 'nightingale' ),
+			'description' => esc_html__( 'Choose whether to display image on blog listing page as square or default (square will ensure all blocks are consistently laid out)', 'nightingale' ),
+			'choices'     => array(
+				'default'  => esc_html__( 'Leave as default proportions', 'nightingale' ),
+				'nightingale-square-md' => esc_html__( 'Show as square (images may be cropped)', 'nightingale' ),
+			),
+		)
+	);
+
+	$wp_customize->add_setting(
 		// $id
 		'blog_fallback',
 		// $args

--- a/template-parts/content-post.php
+++ b/template-parts/content-post.php
@@ -49,7 +49,7 @@ else :
 				if ( ( 'latest-posts' !== $parent_template_part ) || ( ( 'latest-posts' === $parent_template_part ) && ( 0 !== $display_featured_image ) ) ) {
 					if ( has_post_thumbnail() ) :
 
-						the_post_thumbnail( 'default', [ 'class' => 'nhsuk-card__img' ] );
+						the_post_thumbnail( 'nightingale-square-md', [ 'class' => 'nhsuk-card__img' ] );
 
 					else :
 

--- a/template-parts/content-post.php
+++ b/template-parts/content-post.php
@@ -49,7 +49,8 @@ else :
 				if ( ( 'latest-posts' !== $parent_template_part ) || ( ( 'latest-posts' === $parent_template_part ) && ( 0 !== $display_featured_image ) ) ) {
 					if ( has_post_thumbnail() ) :
 
-						the_post_thumbnail( 'nightingale-square-md', [ 'class' => 'nhsuk-card__img' ] );
+						$image_proportion = get_theme_mod( 'blog_image_display', 'default' );
+						the_post_thumbnail( $image_proportion, [ 'class' => 'nhsuk-card__img' ] );
 
 					else :
 

--- a/template-parts/core-latest-posts.php
+++ b/template-parts/core-latest-posts.php
@@ -16,7 +16,7 @@ so we can then pass them down to the display elements correctly
 */
 $parent_template_part   = 'latest-posts';
 $archive_paged          = get_query_var( 'paged' ) ? get_query_var( 'paged' ) : 1;
-$posts_to_show          = get_query_var( 'postsToShow' ) ? get_query_var( 'postsToShow' ) : 5; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+$posts_to_show          = get_query_var( 'postsToShow' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 $categories             = get_query_var( $namespace . 'categories' );
 $display_post_content   = get_query_var( $namespace . 'displayPostContent' ) ? get_query_var( $namespace . 'displayPostContent' ) : 0; // Default to not show post content.
 $excerpt_length         = get_query_var( $namespace . 'excerptLength' ) ? get_query_var( $namespace . 'excerptLength' ) : 20; // Default excerpt length of 20 words.
@@ -37,12 +37,12 @@ $args = array(
 	'paged'               => $archive_paged,
 );
 
-
 if ( ( isset( $categories ) ) && ( ! empty( $categories ) ) ) {
-	$args['cat'] = $categories;
+	foreach ($categories as $cat) {
+		$catout[] = $cat['id'];
+	}
+	$args['category__in'] = $catout;
 }
-
-
 
 $sidebar = nightingale_show_sidebar();
 
@@ -50,7 +50,7 @@ $the_query = new WP_Query( $args );
 
 // The Loop.
 if ( $the_query->have_posts() ) : ?>
-	<div class="nhsuk-grid-row nhsuk-card-group">
+    <div class="nhsuk-grid-row nhsuk-card-group">
 
 		<?php
 		while ( $the_query->have_posts() ) :
@@ -66,10 +66,60 @@ if ( $the_query->have_posts() ) : ?>
 
 		<?php endwhile; ?>
 
-	</div>
+    </div>
+    <nav class="nhsuk-pagination" role="navigation" aria-label="Pagination">
+        <ul class="nhsuk-list nhsuk-pagination__list">
+			<?php
+			$postsorder = get_query_var( $namespace . 'order' ) ? get_query_var( $namespace . 'order' ) : 'desc';
+			$newer = __('View more recent posts', 'nightingale');
+			$older = __('View older posts', 'nightingale');
+			if( 'desc' === $postsorder ) {
+				$prevtext = $newer;
+				$nexttext = $older;
+			} elseif( 'asc' === $postsorder ) {
+				$prevtext = $older;
+				$nexttext = $newer;
+			} else {
+				$prevtext = '';
+				$nexttext = '';
+			}
+			echo get_query_var( $namespace . 'order' );
+			$prevpage = (int) $paged - 1;
+			if ( ! is_single() && $the_query->max_num_pages > 1 && $prevpage > 0 ) {
+				?>
+                <li class="nhsuk-pagination-item--previous">
+                    <a class="nhsuk-pagination__link nhsuk-pagination__link--prev" href="<?php echo previous_posts( false ); ?>">
+                        <span class="nhsuk-pagination__title"><?php _e('Previous', 'nightingale'); ?></span>
+                        <span class="nhsuk-u-visually-hidden">:</span>
+                        <span class="nhsuk-pagination__page"><?php echo $prevtext; ?></span>
+                        <svg class="nhsuk-icon nhsuk-icon__arrow-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+                            <path d="M4.1 12.3l2.7 3c.2.2.5.2.7 0 .1-.1.1-.2.1-.3v-2h11c.6 0 1-.4 1-1s-.4-1-1-1h-11V9c0-.2-.1-.4-.3-.5h-.2c-.1 0-.3.1-.4.2l-2.7 3c0 .2 0 .4.1.6z"></path>
+                        </svg>
 
-	<?php
-	the_posts_pagination();
+                    </a>
+                </li>
+				<?php
+			}
+
+			$nextpage = (int) $paged + 1;
+			if ( ! is_single() && ( $nextpage <= $the_query->max_num_pages ) && ( 1 != $the_query->max_num_pages ) ) {
+				?>
+                <li class="nhsuk-pagination-item--next">
+                    <a class="nhsuk-pagination__link nhsuk-pagination__link--next" href="<?php echo next_posts( $max_page, false ); ?>">
+                        <span class="nhsuk-pagination__title"><?php _e('Next', 'nightingale'); ?></span>
+                        <span class="nhsuk-u-visually-hidden">:</span>
+                        <span class="nhsuk-pagination__page"><?php echo $nexttext; ?></span>
+                        <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+                            <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
+                        </svg>
+                    </a>
+                </li>
+				<?php
+			}
+			?>
+        </ul>
+    </nav>
+<?php
 endif;
 
 /* Restore original Post Data */


### PR DESCRIPTION
 - Added three new nightingale specific image thumbnail sizes - all square at 200px, 500px and 1000px
 - changed post listings to use the medium version by default (all versions get loaded in srscet so retina display retained)
 - when this goes out to sites, we will need to regen thumbnails if the layout is desired to reflect on historic posts
![Screenshot 2021-01-21 at 17 25 18](https://user-images.githubusercontent.com/44897304/105388647-d2bf9300-5c0e-11eb-8d56-1b42dad910fc.png)
