### PR TITLE
[refs #DI-2766] Add info about Google login

### DIFF
--- a/tribe/events/blocks/event-links.php
+++ b/tribe/events/blocks/event-links.php
@@ -26,7 +26,7 @@ remove_filter( 'the_content', 'do_blocks', 9 );
 if ( $should_render ) :
 ?>
 	<div class="tribe-block tribe-block__events-link">
-		<h3 class="nhsuk-heading-s">Calendar Links</h3>
+		<h3 class="nhsuk-heading-s"><?php _e('Calendar Links','nightingale') ?></h3>
 		<p> <?php _e('The following links allow you to add this event to your calendar. Note: You need to be logged into your Google account before you can add to your Google calendar.','nightingale') ?></p>
 		<?php if ( $has_google_cal ) : ?>
 			<div class="tribe-block__btn--link tribe-block__events-gcal">

--- a/tribe/events/blocks/event-links.php
+++ b/tribe/events/blocks/event-links.php
@@ -27,7 +27,7 @@ if ( $should_render ) :
 ?>
 	<div class="tribe-block tribe-block__events-link">
 		<h3 class="nhsuk-heading-s">Calendar Links</h3>
-		<p> <?php echo __('The following links allow you to add this event to your calendar. Note: You need to be logged into your Google account before you can add to your Google calendar.','nightingale') ?></p>
+		<p> <?php _e('The following links allow you to add this event to your calendar. Note: You need to be logged into your Google account before you can add to your Google calendar.','nightingale') ?></p>
 		<?php if ( $has_google_cal ) : ?>
 			<div class="tribe-block__btn--link tribe-block__events-gcal">
 				<a

--- a/tribe/events/blocks/event-links.php
+++ b/tribe/events/blocks/event-links.php
@@ -26,8 +26,8 @@ remove_filter( 'the_content', 'do_blocks', 9 );
 if ( $should_render ) :
 ?>
 	<div class="tribe-block tribe-block__events-link">
-		<h3>Calendar Links</h3>
-		<p>The following links allow you to add this event to your calendar. Note: You need to be logged into your Google account before you can add to your Google calendar.</p>
+		<h3 class="nhsuk-heading-s">Calendar Links</h3>
+		<p> <?php echo __('The following links allow you to add this event to your calendar. Note: You need to be logged into your Google account before you can add to your Google calendar.','nightingale') ?></p>
 		<?php if ( $has_google_cal ) : ?>
 			<div class="tribe-block__btn--link tribe-block__events-gcal">
 				<a

--- a/tribe/events/blocks/event-links.php
+++ b/tribe/events/blocks/event-links.php
@@ -26,6 +26,8 @@ remove_filter( 'the_content', 'do_blocks', 9 );
 if ( $should_render ) :
 ?>
 	<div class="tribe-block tribe-block__events-link">
+		<h3>Calendar Links</h3>
+		<p>The following links allow you to add this event to your calendar. Note: You need to be logged into your Google account before you can add to your Google calendar.</p>
 		<?php if ( $has_google_cal ) : ?>
 			<div class="tribe-block__btn--link tribe-block__events-gcal">
 				<a


### PR DESCRIPTION
Inform users they need to be logged into their Google account before they can use the Add to Google calendar link.

![Screenshot 2021-01-22 at 12 47 51](https://user-images.githubusercontent.com/1991226/105493271-14087f00-5cb1-11eb-8455-b7a68ac0f08c.png)