### PR TITLE
[refs #DI-2805] Increase word count contrast

### DIFF
--- a/assets/scss/gravity-forms.scss
+++ b/assets/scss/gravity-forms.scss
@@ -383,5 +383,6 @@
 // Increase contrast on word count under paragraph box, etc.
 .gp-word-count-label {
 	background: white;
-	color: $color_nhsuk-black;			
+	color: $color_nhsuk-black;
+	padding: nhsuk-spacing(1);
 }

--- a/assets/scss/gravity-forms.scss
+++ b/assets/scss/gravity-forms.scss
@@ -379,3 +379,9 @@
 	}
   }
 }
+
+// Increase contrast on word count under paragraph box, etc.
+.gp-word-count-label {
+	background: white;
+	color: $color_nhsuk-black;			
+}


### PR DESCRIPTION
To improve accessibility increase contrast between text and background on word count messages under text boxes, etc.

Before:
![Screenshot 2021-01-22 at 15 35 15](https://user-images.githubusercontent.com/1991226/105513362-1f1bd900-5cca-11eb-9639-ef73f61a00b1.png)

After:
![Screenshot 2021-01-22 at 15 47 43](https://user-images.githubusercontent.com/1991226/105513396-2b079b00-5cca-11eb-9b59-882b8a54396c.png)
