### PR TITLE
added in additional nonce declaration to prevent naming clash on form…

### DIFF
--- a/learndash/ld30/learndash_pager.php
+++ b/learndash/ld30/learndash_pager.php
@@ -29,7 +29,7 @@ if ( ( isset( $pager_results ) ) && ( ! empty( $pager_results ) ) ) {
 		$href_val_prefix = '';
 	}
 	// Generic wrappers. These can be changes via the switch below.
-	$wrapper_before = ' <nav role="navigation" aria-label="Pagination Navigation" class="learndash-pager learndash-pager-' . $pager_context . '">
+	$wrapper_before = ' <nav role="navigation" aria-label="Pagination Navigation" class="learndash-pager learndash-pager-' . $pager_context . '"  data-nonce="' . wp_create_nonce( 'learndash-pager' ) . '">
 							<ul>';
 	$wrapper_after  = '      </ul>
 						</nav>';


### PR DESCRIPTION
Used the all_fields plugin to add in a template for the generated output which _doesnt_ have broken markup and therefore doesnt break the submit button functionality. This approach uses <ul> and <li> instead of table output, and the scss extends out the nhsuk-frontend summary styling

![Screenshot 2021-02-22 at 16 02 27](https://user-images.githubusercontent.com/44897304/108737098-284ad080-752a-11eb-9cab-8c07cca98c2a.png)
