### PR TITLE
DI-4623 Fix to latest posts not limiting to set number fixes #513 

### DIFF
--- a/template-parts/core-latest-posts.php
+++ b/template-parts/core-latest-posts.php
@@ -20,7 +20,7 @@ if ( is_front_page() ) {
 } else {
 	$archive_paged = get_query_var( 'paged' ) ? get_query_var( 'paged' ) : 1;
 }
-$posts_to_show = get_query_var( 'postsToShow' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+$posts_to_show = get_query_var( $namespace . 'postsToShow' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 if ( isset( $_POST['cat_filter'] ) && ( ! empty( $_POST['cat_filter'] ) ) ) {                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         // phpcs:ignore WordPress.Security.NonceVerification.Missing
 	$cat_filter   = sanitize_text_field( wp_unslash( $_POST['cat_filter'] ) );                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          // phpcs:ignore WordPress.Security.NonceVerification.Missing
 	$categories[] = array(


### PR DESCRIPTION
The 'latest posts' block  does not seem to limit the number of posts to display after a number is set in the block attributes.
