### PR TITLE
Remove closing tag

### DIFF
--- a/page.php
+++ b/page.php
@@ -45,4 +45,3 @@ flush();
 <?php
 flush();
 get_footer();
-?>


### PR DESCRIPTION
The page.php template includes a closing tag at the end of the file. 

It is suggested that the closing tag `?>` be omited from the end of php files so unwanted whitespace will not occur at the end of file, and you will still be able to add headers to the response later. It is also more consistent as the other page templates omit the closing tag. 

Fixes #588

See official references supporting this change:

[PSR-2](https://www.php-fig.org/psr/psr-2/#22-files)
[PHP.net](https://www.php.net/manual/en/language.basic-syntax.instruction-separation.php#:~:text=Note%3A,headers%20to%20the%20response%20later)