### PR TITLE
DI-5751 Style fix for gravity forms chained drop-downs

### DIFF
--- a/inc/gravity-forms.php
+++ b/inc/gravity-forms.php
@@ -515,7 +515,15 @@ function nightingale_clean_gf_inputs( $field_content, $field, $value, $lead_id, 
 				$field_content = preg_replace( $find, $replace, $field_content );
 				$field_content = str_replace( 'nhsuk-checkboxes__input  nhsuk-radios__input', 'nhsuk-checkboxes__input', $field_content );
 				break;
-
+			// Chained Selects.
+			case 'chainedselect':
+				if ( 1 === $errorflag ) {
+					$errorclass = 'nhsuk-select--error';
+				}
+				$find[]        = '<select';
+				$replace[]     = '<select class="gfield_select nhsuk-select ' . $errorclass . '"';
+				$field_content = str_replace( $find, $replace, $field_content );
+				break;
 			default: // everything else.
 				$field_content = $field_content;
 				break;

--- a/readme.txt
+++ b/readme.txt
@@ -46,6 +46,7 @@ one level only. To show further levels, we recommend using the right (or left) h
 =2.5.1=
 * Vulnerability fixes.
 * Node package updates
+* Style fix for gravity forms chained drop-downs
 * Code improvements
 
 =2.5.0=


### PR DESCRIPTION
Nightingale Style fix for gravity forms chained drop-downs looks broken especially in safari.

![image](https://github.com/NHSLeadership/nightingale-2-0/assets/1468647/99c4c806-8634-419c-ba5d-50ef6256ffa6)
