### PR TITLE
DIG-7884 Version info changes for download monitor fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Nightingale 2.7.8
-<img src="https://img.shields.io/badge/nightingale-v2.7.8-blue"> 
+# Nightingale 2.7.9
+<img src="https://img.shields.io/badge/nightingale-v2.7.9-blue"> 
 <a href="https://github.com/nhsuk/nhsuk-frontend">
 <img src="https://img.shields.io/badge/nhsuk--frontend-v8.3.0-blue"></a> <a href="https://www.gnu.org/licenses/gpl-3.0.en.html"><img src="https://img.shields.io/badge/license-GPL%20(%3E%3D3)-green"></a> <a href="https://wordpress.org"><img src="https://img.shields.io/badge/WordPress-v5.5%20%2B-lightgrey"></a> <img src="https://img.shields.io/badge/php-8.0%2B-red"> <img src="https://img.shields.io/badge/pull%20requests-welcome-blueviolet"> <a href="https://wordpress.org/themes/nightingale"><img src="https://img.shields.io/badge/theme%20install-WP%20repo-lightgrey"></a>
 

--- a/functions.php
+++ b/functions.php
@@ -5,7 +5,7 @@
  * @link      https://developer.wordpress.org/themes/basics/theme-functions/
  * @package   Nightingale
  * @copyright NHS Leadership Academy, Mahesh Murali P and Tony Blacker
- * @version   2.7.8 12 nov 2025
+ * @version   2.7.9 2 dec 2025
  */
 
 /**

--- a/index.php
+++ b/index.php
@@ -9,7 +9,7 @@
  * @link      https://developer.wordpress.org/themes/basics/template-hierarchy/
  * @package   Nightingale
  * @copyright NHS Leadership Academy, Mahesh Murali P and Tony Blacker
- * @version   2.7.8 12th November 2025
+ * @version   2.7.9 2nd December 2025
  */
 
 get_header();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nightingale",
-  "version": "2.7.8",
+  "version": "2.7.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nightingale",
-      "version": "2.7.8",
+      "version": "2.7.9",
       "license": "ISC",
       "dependencies": {
         "nhsuk-frontend": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/NHSLeadership/nightingale-2-0.git"
   },
-  "version": "2.7.8",
+  "version": "2.7.9",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Requires PHP: 8.0
 License: GPL v3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.en.html
 Theme URI: https://digital.leadershipacademy.nhs.uk/digital-capabilities/websites/nightingale-theme-user-guide/
-Version: 2.7.8
+Version: 2.7.9
 Stable tag: 2.7
 
 
@@ -42,6 +42,9 @@ one level only. To show further levels, we recommend using the right (or left) h
  behaves and whether the top level page is linked etc.
 
 == Changelog
+
+=2.7.9=
+* Fix translation call in Download Monitor template
 
 =2.7.8=
 * Adds option to set customisable copyright text

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 /*
 Theme Name: Nightingale
 Text Domain: nightingale
-Version: 2.7.8
+Version: 2.7.9
 Requires at least: 5.0
 Tested up to: 6
 Requires PHP: 8.0

--- a/style.scss
+++ b/style.scss
@@ -2,7 +2,7 @@
 /*
 Theme Name: Nightingale
 Text Domain: nightingale
-Version: 2.7.8
+Version: 2.7.9
 Requires at least: 5.0
 Tested up to: 6
 Requires PHP: 8.0


### PR DESCRIPTION
Update version numbers to 2.7.9 across documentation and theme files. Add a changelog entry for a translation fix in the Download Monitor template.