### PR TITLE
DIG-8112  Fix pagination focus order and update changelog

### DIFF
--- a/inc/pagination.php
+++ b/inc/pagination.php
@@ -26,10 +26,11 @@ function nightingale_archive_pagination() {
 
 	$paginate = paginate_links(
 		array(
-			'mid_size'  => 2,
-			'prev_text' => $args['prev_text'],
-			'next_text' => $args['next_text'],
-			'type'      => 'array',
+			'mid_size'           => 2,
+			'prev_text'          => $args['prev_text'],
+			'next_text'          => $args['next_text'],
+			'type'               => 'array',
+			'before_page_number' => '<span class="nhsuk-u-visually-hidden">Page </span>',
 		)
 	);
 
@@ -194,4 +195,3 @@ function nightingale_split_post_pagination( $output ) {
 	$output = str_replace( '"post-page-numbers"', '"post-page-numbers nhsuk-tag nhsuk-tag--grey"', $output );
 	return $output;
 }
-

--- a/inc/pagination.php
+++ b/inc/pagination.php
@@ -42,26 +42,33 @@ function nightingale_archive_pagination() {
 		$first_item = array_slice( $paginate, 0, 1 )[0];
 		$last_item  = array_slice( $paginate, $count, 1 )[0];
 
-		if ( false !== strpos( $last_item, 'class="next page-numbers"' ) ) {
+		$prev_markup = '';
+		$next_markup = '';
 
-			$pagination .= "<li class='nhsuk-pagination-item--next'>{$last_item}</li>";
+		// Capture next, to output later.
+		if ( false !== strpos( $last_item, 'class="next page-numbers"' ) ) {
+			$next_markup = "<li class='nhsuk-pagination-item--next'>{$last_item}</li>";
 			array_pop( $paginate );
 		}
 
+		// Capture prev, to output later.
 		if ( false !== strpos( $first_item, 'class="prev page-numbers"' ) ) {
-
-			$pagination .= "<li class='nhsuk-pagination-item--previous'>{$first_item}</li>";
+			$prev_markup = "<li class='nhsuk-pagination-item--previous'>{$first_item}</li>";
 			array_shift( $paginate );
-
 		}
 
-		$pagination .= "<li class='nhsuk-pagination-numbers'>";
+		// Output in correct focus order: Previous -> Numbers -> Next.
+		$pagination .= $prev_markup;
 
+		$pagination .= "<li class='nhsuk-pagination-numbers'>";
 		foreach ( $paginate as $element ) {
 			$pagination .= $element;
 		}
+		$pagination .= '</li>';
 
-		$pagination .= '</li></ul></nav></div>';
+		$pagination .= $next_markup;
+
+		$pagination .= '</ul></nav></div>';
 
 		echo $pagination; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -44,7 +44,8 @@ one level only. To show further levels, we recommend using the right (or left) h
 == Changelog
 
 =2.7.10=
-* Fix duplicate IDs in search form when used in header and 404 templates (accessibility).
+* Fix duplicate IDs in search form when used in header and 404 templates (accessibility)
+* Fix keyboard focus order in pagination to follow logical reading order (accessibility)
 * Security update
 
 =2.7.9=

--- a/readme.txt
+++ b/readme.txt
@@ -45,7 +45,7 @@ one level only. To show further levels, we recommend using the right (or left) h
 
 =2.7.10=
 * Fix duplicate IDs in search form when used in header and 404 templates (accessibility)
-* Fix keyboard focus order in pagination to follow logical reading order (accessibility)
+* Improve pagination accessibility by fixing keyboard focus order and adding screen‑reader context to page numbers. (accessibility)
 * Security update
 
 =2.7.9=


### PR DESCRIPTION
- Accessibility: Search Results - Fix for only number is read out to users (when reading page numbers)
- Accessibility: fix for the pagination has the next button focus before the page numbers 
