### PR TITLE
DIG-8258 Add first-published meta and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Nightingale 2.7.11
-<img src="https://img.shields.io/badge/nightingale-v2.7.11-blue"> 
+# Nightingale 2.7.12
+<img src="https://img.shields.io/badge/nightingale-v2.7.12-blue"> 
 <a href="https://github.com/nhsuk/nhsuk-frontend">
 <img src="https://img.shields.io/badge/nhsuk--frontend-v8.3.0-blue"></a> <a href="https://www.gnu.org/licenses/gpl-3.0.en.html"><img src="https://img.shields.io/badge/license-GPL%20(%3E%3D3)-green"></a> <a href="https://wordpress.org"><img src="https://img.shields.io/badge/WordPress-v5.5%20%2B-lightgrey"></a> <img src="https://img.shields.io/badge/php-8.0%2B-red"> <img src="https://img.shields.io/badge/pull%20requests-welcome-blueviolet"> <a href="https://wordpress.org/themes/nightingale"><img src="https://img.shields.io/badge/theme%20install-WP%20repo-lightgrey"></a>
 

--- a/functions.php
+++ b/functions.php
@@ -5,7 +5,7 @@
  * @link      https://developer.wordpress.org/themes/basics/theme-functions/
  * @package   Nightingale
  * @copyright NHS Leadership Academy, Mahesh Murali P and Tony Blacker
- * @version   2.7.11
+ * @version   2.7.12
  */
 
 /**
@@ -362,6 +362,11 @@ require get_template_directory() . '/inc/color-picker.php';
  * Last Reviewed.
  */
 require get_template_directory() . '/inc/last-reviewed.php';
+
+/**
+ * First Published.
+ */
+require get_template_directory() . '/inc/first-published.php';
 
 /**
  * Tabbed Page layout.

--- a/inc/first-published.php
+++ b/inc/first-published.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * First published meta box and front-end display.
+ *
+ * @package   Nightingale-2-0
+ * @copyright NHS Leadership Academy, Mahesh Murali P
+ * @version   April 2024
+ */
+
+/**
+ * Register the first published toggle meta box.
+ */
+function nightingale_firstpublished_metabox() {
+	add_meta_box(
+		'nightingale-first-published-metabox',
+		__( 'Toggle First Published', 'nightingale' ),
+		'nightingale_render_firstpublished',
+		'page',
+		'side',
+		'core'
+	);
+}
+add_action( 'add_meta_boxes', 'nightingale_firstpublished_metabox' );
+
+/**
+ * Renders the first published meta box controls.
+ *
+ * @param WP_Post $post The current post object.
+ */
+function nightingale_render_firstpublished( $post ) {
+
+	wp_nonce_field( basename( __FILE__ ), 'nightingale-first-published-nonce' );
+
+	$sidebar = get_post_meta( $post->ID, 'first-published', true );
+	$checked = ( 'on' === $sidebar );
+	echo '<p>' . esc_html__( 'Toggle first published', 'nightingale' ) . '</p>';
+	echo '<input type="radio" id="first-published-on" name="firstPublished" value="on" ' . checked( $checked, true, false ) . '>';
+	echo '<label for="first-published-on">' . esc_html__( 'On', 'nightingale' ) . '</label><br>';
+	echo '<input type="radio" id="first-published-off" name="firstPublished" value="" ' . checked( $checked, false, false ) . '>';
+	echo '<label for="first-published-off">' . esc_html__( 'Off', 'nightingale' ) . '</label><br>';
+}
+
+/**
+ * Saves the first published meta box value.
+ *
+ * @param int $post_id The post ID.
+ */
+function nightingale_save_firstpublished( $post_id ) {
+	global $pagenow;
+
+	if ( 'post.php' !== $pagenow && 'post-new.php' !== $pagenow ) {
+		return;
+	}
+
+	$is_autosave = wp_is_post_autosave( $post_id );
+	$is_revision = wp_is_post_revision( $post_id );
+
+	$nonce = '';
+	if ( isset( $_POST['nightingale-first-published-nonce'] ) ) {
+		$nonce = sanitize_text_field( wp_unslash( $_POST['nightingale-first-published-nonce'] ) );
+	}
+
+	$is_valid_nonce = ( ! empty( $nonce ) && wp_verify_nonce( $nonce, basename( __FILE__ ) ) );
+
+	if ( $is_autosave || $is_revision || ! $is_valid_nonce ) {
+		return;
+	}
+
+	if ( isset( $_POST['firstPublished'] ) ) {
+		$first_published = sanitize_text_field( wp_unslash( $_POST['firstPublished'] ) );
+		update_post_meta( $post_id, 'first-published', $first_published );
+	}
+}
+add_action( 'save_post', 'nightingale_save_firstpublished' );
+
+add_action( 'page_after_content', 'nightingale_page_first_published', 10 );
+/**
+ * Displays the first published date on the page.
+ */
+function nightingale_page_first_published() {
+	$display = get_post_meta( get_the_id(), 'first-published', true );
+
+	if ( 'on' !== $display ) {
+		return;
+	}
+
+	$published_date = get_the_time( 'j F Y' );
+	echo '<div class="nhsuk-review-date nhsuk-first-published-date">';
+	echo '<p class="nhsuk-body-s">' . esc_html__( 'First published', 'nightingale' ) . ': ' . esc_html( $published_date ) . '</p>';
+	echo '</div>';
+}

--- a/inc/first-published.php
+++ b/inc/first-published.php
@@ -4,7 +4,7 @@
  *
  * @package   Nightingale-2-0
  * @copyright NHS Leadership Academy, Mahesh Murali P
- * @version   April 2024
+ * @version   2.7.12
  */
 
 /**
@@ -46,32 +46,44 @@ function nightingale_render_firstpublished( $post ) {
  * @param int $post_id The post ID.
  */
 function nightingale_save_firstpublished( $post_id ) {
-	global $pagenow;
-
-	if ( 'post.php' !== $pagenow && 'post-new.php' !== $pagenow ) {
+	// Only run on page edits in the admin.
+	if ( ! is_admin() ) {
 		return;
 	}
 
-	$is_autosave = wp_is_post_autosave( $post_id );
-	$is_revision = wp_is_post_revision( $post_id );
-
-	$nonce = '';
-	if ( isset( $_POST['nightingale-first-published-nonce'] ) ) {
-		$nonce = sanitize_text_field( wp_unslash( $_POST['nightingale-first-published-nonce'] ) );
-	}
-
-	$is_valid_nonce = ( ! empty( $nonce ) && wp_verify_nonce( $nonce, basename( __FILE__ ) ) );
-
-	if ( $is_autosave || $is_revision || ! $is_valid_nonce ) {
+	// Optional but recommended: ensure we're saving the right post type.
+	if ( 'page' !== get_post_type( $post_id ) ) {
 		return;
 	}
 
+	// Bail on autosave / revisions.
+	if ( wp_is_post_autosave( $post_id ) || wp_is_post_revision( $post_id ) ) {
+		return;
+	}
+
+	// Verify nonce.
+	if ( ! isset( $_POST['nightingale-first-published-nonce'] ) ) {
+		return;
+	}
+
+	$nonce = sanitize_text_field( wp_unslash( $_POST['nightingale-first-published-nonce'] ) );
+	if ( ! wp_verify_nonce( $nonce, basename( __FILE__ ) ) ) {
+		return;
+	}
+
+	// ✅ Capability check (addresses the code review comment).
+	if ( ! current_user_can( 'edit_post', $post_id ) ) {
+		return;
+	}
+
+	// Save the setting.
 	if ( isset( $_POST['firstPublished'] ) ) {
 		$first_published = sanitize_text_field( wp_unslash( $_POST['firstPublished'] ) );
 		update_post_meta( $post_id, 'first-published', $first_published );
 	}
 }
 add_action( 'save_post', 'nightingale_save_firstpublished' );
+
 
 add_action( 'page_after_content', 'nightingale_page_first_published', 10 );
 /**

--- a/inc/first-published.php
+++ b/inc/first-published.php
@@ -71,7 +71,7 @@ function nightingale_save_firstpublished( $post_id ) {
 		return;
 	}
 
-	// ✅ Capability check (addresses the code review comment).
+	// Capability check (addresses the code review comment).
 	if ( ! current_user_can( 'edit_post', $post_id ) ) {
 		return;
 	}

--- a/inc/last-reviewed.php
+++ b/inc/last-reviewed.php
@@ -26,7 +26,7 @@
 function nightingale_lastreviewed_metabox() {
 	add_meta_box(
 		'nightingale-last-reviewed-metabox',
-		__( 'Toggle Page Reviewd', 'nightingale' ),
+		__( 'Toggle Page Reviewed', 'nightingale' ),
 		'nightingale_render_lastreviewed',
 		'page',
 		'side',
@@ -110,7 +110,7 @@ function nightingale_save_lastreviewed( $post_id ) {
 
 add_action( 'save_post', 'nightingale_save_lastreviewed' );
 
-add_action( 'page_after_content', 'nightingale_page_last_reviewed' );
+add_action( 'page_after_content', 'nightingale_page_last_reviewed', 20 );
 
 /**
  * Displays the last reviewed date on the post.

--- a/index.php
+++ b/index.php
@@ -9,7 +9,7 @@
  * @link      https://developer.wordpress.org/themes/basics/template-hierarchy/
  * @package   Nightingale
  * @copyright NHS Leadership Academy, Mahesh Murali P and Tony Blacker
- * @version   2.7.11 26th Feb 2026
+ * @version   2.7.12 16th Apr 2026
  */
 
 get_header();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nightingale",
-  "version": "2.7.11",
+  "version": "2.7.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nightingale",
-      "version": "2.7.11",
+      "version": "2.7.12",
       "license": "ISC",
       "dependencies": {
         "nhsuk-frontend": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/NHSLeadership/nightingale-2-0.git"
   },
-  "version": "2.7.11",
+  "version": "2.7.12",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Requires PHP: 8.0
 License: GPL v3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.en.html
 Theme URI: https://digital.leadershipacademy.nhs.uk/digital-capabilities/websites/nightingale-theme-user-guide/
-Version: 2.7.11
+Version: 2.7.12
 Stable tag: 2.7
 
 
@@ -42,6 +42,9 @@ one level only. To show further levels, we recommend using the right (or left) h
  behaves and whether the top level page is linked etc.
 
 == Changelog
+
+=2.7.12=
+* Add optional First published date to page metadata display, shown alongside Page last reviewed.
 
 =2.7.11=
 * Accessibility improvements to category and tag links

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 /*
 Theme Name: Nightingale
 Text Domain: nightingale
-Version: 2.7.11
+Version: 2.7.12
 Requires at least: 5.0
 Tested up to: 6
 Requires PHP: 8.0

--- a/style.scss
+++ b/style.scss
@@ -2,7 +2,7 @@
 /*
 Theme Name: Nightingale
 Text Domain: nightingale
-Version: 2.7.11
+Version: 2.7.12
 Requires at least: 5.0
 Tested up to: 6
 Requires PHP: 8.0


### PR DESCRIPTION
Introduce a new First published meta box  to toggle, save and display an optional 'First published' date on pages;